### PR TITLE
BCE-9830: fixing the set-prune-marker container to run the right command

### DIFF
--- a/avalanche.yml
+++ b/avalanche.yml
@@ -84,7 +84,7 @@ services:
     volumes:
       - ava-data:/home/avalanche/.avalanchego
     entrypoint: ["/bin/sh","-c"]
-    command: /bin/sh
+    command: touch /home/avalanche/.avalanchego/prune-marker
 
 volumes:
   ava-data:


### PR DESCRIPTION
fixing this container to trigger the offline pruning script in `set-prune.sh` of the `ava-init` container
this should fix it so that you can manually run this service and it will create the required file